### PR TITLE
feat: prepare for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -6,6 +6,10 @@ on:
     types: [completed]
     branches: [develop]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish-preview:
     name: Publish Preview Packages
@@ -38,9 +42,13 @@ jobs:
         if: steps.changesets-check.outputs.has_changesets == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      - name: Update npm
+        if: steps.changesets-check.outputs.has_changesets == 'true'
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         if: steps.changesets-check.outputs.has_changesets == 'true'
@@ -54,7 +62,7 @@ jobs:
         if: steps.changesets-check.outputs.has_changesets == 'true'
         run: |
           pnpm changeset version --snapshot preview
-          pnpm changeset publish --tag preview
+          pnpm changeset publish --tag preview --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   release:
     name: Release Packages
@@ -23,9 +28,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      - run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,7 +43,7 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          publish: pnpm changeset publish --provenance
           title: "chore: version packages"
           commit: "chore: version packages"
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/claude-code-interface/package.json
+++ b/packages/claude-code-interface/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Types and interfaces for Claude Code plugin consumers",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/claude-code-interface"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-interface/package.json
+++ b/packages/git-interface/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Git interface types and utilities for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/git-interface"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/github-actions-interface/package.json
+++ b/packages/github-actions-interface/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "TypeScript type definitions for GitHub Actions concepts extending core Latency types",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/github-actions-interface"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/github-issues-interface/package.json
+++ b/packages/github-issues-interface/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "GitHub Issues interface types and utilities for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/github-issues-interface"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/jira-interface/package.json
+++ b/packages/jira-interface/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Jira-specific types and helpers for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/jira-interface"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-claude-code/package.json
+++ b/packages/latency-plugin-claude-code/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Claude Code CLI plugin for the Latency dev agent ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-claude-code"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-dev-agent/package.json
+++ b/packages/latency-plugin-dev-agent/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Abstract dev agent plugin providing common logic for AI agent implementations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-dev-agent"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-git/package.json
+++ b/packages/latency-plugin-git/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Git source control plugin for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-git"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-github-actions/package.json
+++ b/packages/latency-plugin-github-actions/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "GitHub Actions CI/CD plugin for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-github-actions"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-github-issues/package.json
+++ b/packages/latency-plugin-github-issues/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "GitHub Issues plugin implementation for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-github-issues"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-health-check/package.json
+++ b/packages/latency-plugin-health-check/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Health check plugin for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-health-check"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-issue-tracker/package.json
+++ b/packages/latency-plugin-issue-tracker/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Abstract issue tracker plugin for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-issue-tracker"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-jira/package.json
+++ b/packages/latency-plugin-jira/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Jira issue tracker plugin for the Latency ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-jira"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency-plugin-source-control/package.json
+++ b/packages/latency-plugin-source-control/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Abstract source control plugin providing common validation and shared logic for all VCS implementations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency-plugin-source-control"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/latency/package.json
+++ b/packages/latency/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Latency monitoring and performance tracking for the Tetrad ecosystem",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/latency"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/plugin-ci-cd/package.json
+++ b/packages/plugin-ci-cd/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "Abstract CI/CD plugin providing common logic for all pipeline implementations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generacy-ai/latency.git",
+    "directory": "packages/plugin-ci-cd"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Update all workflows to Node 22 (required for npm >= 11.5.1 OIDC support)
- Add `id-token: write` permissions for OIDC authentication
- Add `--provenance` flag to publish commands
- Add `repository` field to all 16 package.json files (required for provenance attestations)
- Remove `.npmrc` (not needed — changesets/action handles auth setup)

## Migration to OIDC
The workflows are forward-compatible: while `NPM_TOKEN` org secret exists, token-based auth is used (needed for initial publish). After configuring trusted publishers on npmjs.com and removing the `NPM_TOKEN` secret, OIDC takes over automatically.

## Test plan
- [ ] CI passes (lint, build, test)
- [ ] After merge + push to main: initial publish succeeds with granular NPM token
- [ ] Configure trusted publishers on npmjs.com for each package
- [ ] Remove NPM_TOKEN secret → verify OIDC publish works

🤖 Generated with [Claude Code](https://claude.com/claude-code)