### PR TITLE
fix: seed @preview dist-tag for @generacy-ai/latency

### DIFF
--- a/.changeset/preview-tag-seed.md
+++ b/.changeset/preview-tag-seed.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/latency": patch
+---
+
+Seed preview dist-tag for downstream dependency resolution


### PR DESCRIPTION
## Summary
- Adds a patch changeset for `@generacy-ai/latency` so the `publish-preview` workflow will publish a snapshot version under the `@preview` npm dist-tag
- The `@preview` tag currently does not exist on npm because the v0.1.0 release consumed all changesets, leaving none for the preview workflow to act on
- This unblocks all downstream agency preview publishes which require `@generacy-ai/latency@preview` to resolve

## Context
The `publish-preview.yml` workflow checks for `.changeset/*.md` files (excluding README.md). When none are found, it skips the publish entirely. Since v0.1.0 was released and consumed the changesets, no preview snapshots have been published, meaning the `@preview` dist-tag was never created.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge to develop, confirm the `publish-preview` workflow triggers and publishes successfully
- [ ] Verify `npm view @generacy-ai/latency dist-tags` shows a `preview` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)