### PR TITLE
chore: skip CI on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [develop, main]
 
@@ -13,6 +14,7 @@ jobs:
   ci:
     name: Build, Lint, Test
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Adds `ready_for_review` to `pull_request.types` and gates the CI job on `github.event.pull_request.draft == false`.
- CI now stays idle while a PR is in draft and kicks in the moment the PR is marked ready.
- Push-triggered runs on `develop`/`main` are unaffected (guarded by `github.event_name != 'pull_request'`).

Affects: `ci.yml`.

## Test plan
- [ ] Open a draft PR and confirm CI does not run.
- [ ] Mark it ready for review and confirm CI runs.
- [ ] Push to `develop` and confirm CI still runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)