### PR TITLE
fix(release): publish to npm `stable` dist-tag from main

### DIFF
--- a/.changeset/initial-stable-release.md
+++ b/.changeset/initial-stable-release.md
@@ -1,0 +1,5 @@
+---
+"@generacy-ai/latency": patch
+---
+
+Publish to the `stable` npm dist-tag. No code changes — this changeset exists to force a version+publish cycle so a `stable` dist-tag is created on npm (the orchestrator entrypoint installs `@generacy-ai/*@stable`, but `stable` was never populated for any package — only `latest`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          publish: pnpm changeset publish
+          publish: pnpm changeset publish --tag stable
           title: "chore: version packages"
           commit: "chore: version packages"
         env:


### PR DESCRIPTION
## Summary

- Adds `--tag stable` to `pnpm changeset publish` in [.github/workflows/release.yml](.github/workflows/release.yml) so merges to `main` land packages on the `stable` npm dist-tag (not `latest`).
- Adds an initial changeset for `@generacy-ai/latency` so the next merge to `main` actually triggers a version+publish cycle (no changesets pending on main means `changesets/action` is a no-op otherwise).

## Why

The orchestrator devcontainer entrypoint runs `npm install @generacy-ai/*@stable`. Current npm dist-tags for all 16 latency packages only contain `latest` (pointing at `0.1.1`) — `stable` was never populated, so `npm install …@stable` fails with `ETARGET`.

Mirrors the same fix already landed in:
- agency: #340 (fix/publish-stable-tag → main)
- generacy: #485 (fix/publish-stable-tag → main)

Latency is the last of the three npm-publishing repos still missing the fix.

## Notes

- `latest` will still point at `0.1.1` after this change. If we want `npm install @generacy-ai/latency` (no tag) to resolve to the new stable release too, a follow-up can alias `latest → stable` via `npm dist-tag add`.
- No code changes — only the workflow + a changeset metadata file.

## Test plan

- [ ] After merge to develop, then develop→main, confirm `changesets/action` opens the Version Packages PR
- [ ] Merge Version Packages PR
- [ ] Verify `npm view @generacy-ai/latency dist-tags` includes `stable`
- [ ] Verify a handful of other latency packages (e.g. `@generacy-ai/latency-plugin-claude-code`, `@generacy-ai/git-interface`) also have `stable`
- [ ] Rebuild orchestrator container and confirm `npm install @generacy-ai/latency@stable` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)